### PR TITLE
Using the same version information for multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-Using `GenerateProductVersion.cmake`
-------------------------------
+# Using `GenerateProductVersion.cmake`
 
-Basic usage:
+## Basic usage
 
 ```cmake
 include(GenerateProductVersion)
@@ -34,3 +33,46 @@ You can specify the resource strings in arguments:
 - ORIGINAL_FILENAME  - ${NAME} is default
 - INTERNAL_NAME      - ${NAME} is default
 - FILE_DESCRIPTION   - ${NAME} is default
+
+## Advanced usage
+
+### Use the same version ProductVersionFiles for multiple targets
+
+If you want to have the same product information for multiple targets (e.g. because you have a project with multiple libraries that all belong together and have the same version) you can do this by using an object library in combination with an interface target:
+
+```cmake
+include(GenerateProductVersion)
+
+GenerateProductVersion(
+    ProductVersionFiles
+    NAME MyProduct
+    COMPANY_NAME MyCompany
+)
+
+add_library(project_version_obj OBJECT ${ProductVersionFiles})
+target_sources(project_version INTERFACE $<TARGET_OBJECTS:project_version_obj>)
+
+# optional: set some more target properties on project_version for cross-platform version information
+# set_target_properties(project_version
+#     PROPERTIES
+#     VERSION ${VERSION_SHORT}-${VERSION_COMMITS}
+#     SOVERSION ${VERSION_MAJOR}
+#     COMPATIBLE_INTERFACE_STRING "${PROJECT_NAME}_MAJOR_VERSION"
+#     "INTERFACE_${PROJECT_NAME}_MAJOR_VERSION" ${VERSION_MAJOR}
+# )
+```
+
+Then you just need to link the `project_version` target to your desired libraries, e.g.:
+
+```cmake
+add_library(my_lib1 ...)
+add_library(my_lib2 ...)
+add_executable(my_exec ...)
+
+target_link_libraries(my_lib1 PRIVATE project_version)
+target_link_libraries(my_lib2 PRIVATE project_version)
+target_link_libraries(my_exec PRIVATE project_version)
+target_link_libraries(my_exec PUBLIC my_lib1 my_lib2)
+```
+
+That way your libraries' DLL files as well as the executable have the same version information.


### PR DESCRIPTION
Hi again,

while changing to your GenerateProductVersion in my project I thought about my solution with the BUILD_INTERFACE generator expression again and I came up with another solution that does not require any changes to the GenerateProductionVersion function *and* is better than my last solution.  
I described this in the README.md. This solution has the advantage that the VersionResource.rc file is only getting built once for all targets that use it and not once for each target (which was the case with my BUILD_INTERFACE solution).

I just made this PR to show you what I came up with (unfortunately, I had to delete my last fork in order to make another fork of your project which is why I couldn't simply continue our conversation in my fork) and if you think this might be helpful for others as well then feel free to merge (I also don't mind if you think this might be too niche and don't want to merge it).